### PR TITLE
Fix starfield distribution: change from repeating tiles to full viewp…

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,24 +13,24 @@ document.addEventListener('DOMContentLoaded', () => {
 	const introBrand = document.querySelector('.intro-brand');
 	const navBrand = document.querySelector('.nav-brand');
 	const navbar = document.querySelector('.navbar');
+	const navEntry = performance.getEntriesByType('navigation')[0];
+	const navType = navEntry ? navEntry.type : (performance.navigation && performance.navigation.type === 1 ? 'reload' : 'navigate');
+	const cameFromStudent = sessionStorage.getItem('fromStudent') === 'true';
 	
-	// Check if user has already seen the intro in this session
-	const hasSeenIntro = sessionStorage.getItem('introPlayed');
+	if (cameFromStudent) {
+		sessionStorage.removeItem('fromStudent');
+	}
+	
+	const shouldPlayIntro = navType === 'reload' || !cameFromStudent;
 	
 	if (introOverlay && introBrand && navBrand && navbar) {
-		
-		// Skip intro if already seen in this session
-		if (hasSeenIntro) {
-			// Remove intro overlay immediately
+		if (!shouldPlayIntro) {
 			introOverlay.remove();
 			document.body.classList.add('intro-complete');
 			initScrollAnimations();
 			initProfileCardClicks();
 			return;
 		}
-		
-		// Mark intro as seen for this session
-		sessionStorage.setItem('introPlayed', 'true');
 		
 		// ============================================
 		// ANIMATION TIMELINE
@@ -117,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			card.addEventListener('click', () => {
 				const id = card.getAttribute('data-id');
 				if (id) {
+					sessionStorage.setItem('fromStudent', 'true');
 					window.location.href = `student.html?id=${id}`;
 				}
 			});
@@ -127,6 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (e.key === 'Enter' || e.key === ' ') {
 					const id = card.getAttribute('data-id');
 					if (id) {
+						sessionStorage.setItem('fromStudent', 'true');
 						window.location.href = `student.html?id=${id}`;
 					}
 				}

--- a/student.html
+++ b/student.html
@@ -37,7 +37,7 @@
 		<!-- PROFILE HERO SECTION ONLY -->
 		<section class="profile-hero-section">
 			<div class="container back-btn-wrapper">
-				<button class="back-btn" onclick="window.location.href='index.html'" aria-label="Back to main page">← Back</button>
+				<button class="back-btn" onclick="sessionStorage.setItem('fromStudent', 'true'); window.location.href='index.html'" aria-label="Back to main page">← Back</button>
 			</div>
 			<div class="container profile-hero-content">
 				<img id="profileImage" class="profile-image" src="" alt="Profile photo" />

--- a/style.css
+++ b/style.css
@@ -36,6 +36,141 @@ body {
     touch-action: pan-y; 
 }
 
+/* Permanent Starfield Background for Full Page */
+body::before,
+body::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-repeat: repeat;
+    animation: starfield-drift 12s linear infinite;
+    opacity: 0.95;
+    pointer-events: none;
+    z-index: 0;
+}
+
+body::before {
+    background-image:
+        radial-gradient(2px 2px at 5% 12%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 10% 28%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 15% 42%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 20% 58%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 25% 22%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 30% 72%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 35% 38%, rgba(255, 255, 255, 0.8), transparent 50%),
+        radial-gradient(2px 2px at 40% 52%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 45% 68%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 50% 45%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 55% 62%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 60% 15%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 65% 78%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 70% 92%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 75% 8%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 80% 48%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 85% 82%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 90% 25%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 95% 55%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 7% 88%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 12% 35%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 18% 68%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 23% 18%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 28% 85%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 33% 32%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 38% 62%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 43% 8%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 48% 75%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 52% 52%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 58% 22%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 63% 45%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 68% 88%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 73% 38%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 78% 48%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 83% 78%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 88% 42%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 93% 72%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 98% 5%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 11% 52%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 16% 15%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 22% 95%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 32% 38%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 37% 65%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 42% 22%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 51% 75%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 57% 35%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 62% 88%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 67% 18%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 72% 52%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 77% 68%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 82% 28%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 87% 85%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 92% 12%, rgba(255, 255, 255, 0.95), transparent 50%);
+    background-size: 100vw 100vh;
+    background-position: 0 0;
+    background-attachment: fixed;
+}
+
+body::after {
+    background-image:
+        radial-gradient(1.5px 1.5px at 5% 38%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 10% 65%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 15% 12%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 20% 82%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 25% 45%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 30% 18%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 35% 72%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 40% 35%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 45% 88%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 50% 58%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 55% 22%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 60% 78%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 65% 48%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 70% 5%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 75% 92%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 80% 62%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 85% 15%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 90% 52%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 95% 28%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 8% 85%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 13% 42%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 18% 8%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 23% 68%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 28% 32%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 33% 95%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 38% 55%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 43% 22%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 48% 78%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 52% 12%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 57% 65%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 62% 42%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 67% 88%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 72% 28%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 77% 58%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 82% 12%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 87% 38%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 92% 82%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 97% 48%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 6% 72%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 11% 22%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 16% 95%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 22% 38%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 27% 75%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 32% 8%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 37% 52%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 42% 65%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 47% 18%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 51% 88%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 56% 32%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 61% 72%, rgba(255, 255, 255, 1), transparent 50%);
+    background-size: 100vw 100vh;
+    background-position: 0 0;
+    background-attachment: fixed;
+    animation: starfield-drift-far 24s linear infinite reverse;
+    opacity: 0.7;
+}
+
 /* =============================================================
    PREMIUM CINEMATIC INTRO ANIMATION
    ============================================================= */
@@ -119,6 +254,114 @@ body:not(.intro-complete) {
     align-items: center;
     justify-content: center;
     opacity: 1;
+    overflow: hidden;
+}
+
+.intro-overlay::before,
+.intro-overlay::after {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background-image:
+        radial-gradient(2px 2px at 8% 12%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 18% 28%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 28% 42%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 38% 58%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 48% 22%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 58% 72%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 68% 38%, rgba(255, 255, 255, 0.8), transparent 50%),
+        radial-gradient(2px 2px at 78% 52%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 88% 68%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 5% 45%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 15% 62%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 25% 15%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 35% 78%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 45% 92%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2.5px 2.5px at 55% 8%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 65% 48%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 75% 82%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 85% 25%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 95% 55%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 10% 88%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 20% 35%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 30% 68%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 40% 18%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 50% 85%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 60% 32%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 70% 62%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 80% 8%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 90% 75%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 12% 52%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 22% 8%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 32% 95%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 42% 48%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 52% 15%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 62% 78%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 72% 28%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 82% 58%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 92% 42%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 6% 72%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 16% 5%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 26% 88%, rgba(255, 255, 255, 0.9), transparent 50%);
+    background-repeat: repeat;
+    background-size: 200px 200px;
+    animation: starfield-drift 12s linear infinite;
+    opacity: 0.95;
+    pointer-events: none;
+    transform: scale(1.15);
+    z-index: 1;
+}
+
+.intro-overlay::after {
+    background-image:
+        radial-gradient(1.5px 1.5px at 14% 38%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 24% 65%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 34% 12%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 44% 82%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 54% 45%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 64% 18%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 74% 72%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 84% 35%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 94% 88%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 3% 58%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 13% 22%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 23% 78%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2px 2px at 33% 48%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2.5px 2.5px at 43% 5%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 53% 92%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 63% 62%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 73% 15%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(1.5px 1.5px at 83% 52%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 93% 28%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2px 2px at 7% 85%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(1.5px 1.5px at 17% 42%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 27% 8%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(2.5px 2.5px at 37% 68%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(1.5px 1.5px at 47% 32%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 57% 95%, rgba(255, 255, 255, 0.95), transparent 50%),
+        radial-gradient(2px 2px at 67% 55%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 77% 22%, rgba(255, 255, 255, 1), transparent 50%),
+        radial-gradient(2.5px 2.5px at 87% 78%, rgba(255, 255, 255, 0.85), transparent 50%),
+        radial-gradient(2px 2px at 97% 48%, rgba(255, 255, 255, 0.9), transparent 50%),
+        radial-gradient(1.5px 1.5px at 11% 12%, rgba(255, 255, 255, 0.95), transparent 50%);
+    background-size: 180px 180px;
+    animation: starfield-drift-far 24s linear infinite reverse;
+    opacity: 0.7;
+    transform: scale(1.35);
+    z-index: 2;
+}
+
+@keyframes starfield-drift {
+    0% { transform: translate3d(0, 0, 0) scale(1); }
+    100% { transform: translate3d(-120px, -160px, 0) scale(1.05); }
+}
+
+@keyframes starfield-drift-far {
+    0% { transform: translate3d(0, 0, 0) scale(1.1); }
+    100% { transform: translate3d(-80px, -120px, 0) scale(1.2); }
 }
 
 /* =============================================================
@@ -214,11 +457,15 @@ header.header.sticky-header {
     align-items: center;
     padding: 0;
     margin: 0;
+    position: relative;
+    z-index: 100;
 }
 
 nav.navbar.container {
     max-width: 100% !important;
     padding: 0 40px;
+    position: relative;
+    z-index: 100;
 }
 
 /* Nav Links */
@@ -273,6 +520,8 @@ main {
     opacity: 0;
     transform: translateY(20px);
     transition: opacity 0.8s ease, transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+    position: relative;
+    z-index: 10;
 }
 
 body.intro-complete main {
@@ -377,6 +626,13 @@ h1, h2, h3, h4, h5, h6 {
     max-width: var(--container-max);
     margin: 0 auto;
     padding: 0 24px;
+    position: relative;
+    z-index: 10;
+}
+
+section {
+    position: relative;
+    z-index: 10;
 }
 .stat-label {
 	color: var(--text-muted);


### PR DESCRIPTION
Restructured the CSS background approach from repeating 200px/180px tiles to a full 100vw/100vh viewport-sized background
Changed body::before and body::after positioning from top: -50%; left: -50%; width: 200%; height: 200% to top: 0; left: 0; width: 100vw; height: 100vh
Removed transform: scale(1.15) and transform: scale(1.35) from pseudo-elements
Added background-attachment: fixed and background-position: 0 0 to both layers
Updated background-size from repeating 200px/180px tiles to single 100vw 100vh viewport coverage